### PR TITLE
Fix 1 character typo in Tel2Idl: dV2 -> dV3

### DIFF
--- a/jwxml.py
+++ b/jwxml.py
@@ -359,7 +359,7 @@ class Aperture(object):
         dV3 = np.asarray(V3, dtype=float)-self.V3Ref
         ang = np.deg2rad(self.V3IdlYAngle)
 
-        XIdl = self.VIdlParity * (dV2 * np.cos(ang) - dV2 * np.sin(ang))
+        XIdl = self.VIdlParity * (dV2 * np.cos(ang) - dV3 * np.sin(ang))
         YIdl =                    dV2 * np.sin(ang) + dV3 * np.cos(ang)
         return XIdl, YIdl
 


### PR DESCRIPTION
`Aperture.Tel2Idl` was not computing the formula from JWST-STScI-001550 correctly. Upon inspection, the issue was `V2 - V2Ref` being used in place of `V3 - V3Ref`.
