### PR TITLE
Update jwxml SUR parsing to handle SURs with ROC moves

### DIFF
--- a/jwxml/mirrors.py
+++ b/jwxml/mirrors.py
@@ -11,7 +11,7 @@ class Segment_Update(object):
     """ Class for representing one single mirror update (will be inside of groups in SURs)
     """
     def __init__(self, xmlnode):
-        if xmlnode.attrib['type'] != 'pose': raise NotImplemented("Only Pose updates supported yet")
+#        if xmlnode.attrib['type'] != 'pose': raise NotImplemented("Only Pose updates supported yet")
 
         self.id = int(xmlnode.attrib['id'])
         self.type = xmlnode.attrib['type']


### PR DESCRIPTION
This simple fix seems to do the trick for handling SURs with ROC updates in them.  This was tested by checking that the ingested SUR with ROC update in it was being reflected in the ote.segment_state as well as visually by generating a PSF with large ROC. 